### PR TITLE
Add Hybrid flow

### DIFF
--- a/samples/generated/static-spa/public/app.js
+++ b/samples/generated/static-spa/public/app.js
@@ -91,8 +91,8 @@ function main() {
     return handleLoginRedirect().then(function() {
       startApp();
     });
-  } 
-  
+  }
+
   // Normal app startup
   startApp();
 }
@@ -182,7 +182,7 @@ function handleLoginRedirect() {
     beginAuthFlow(); // widget will resume transaction
     return Promise.resolve();
   }
-  
+
   // If the URL contains a code, `parseFromUrl` will grab it and exchange the code for tokens
   return authClient.token.parseFromUrl().then(function (res) {
     endAuthFlow(res.tokens); // save tokens
@@ -222,6 +222,7 @@ function beginAuthFlow() {
       showSigninWidget();
       break;
     case 'form':
+    case 'hybrid':
       showSigninForm();
       break;
   }
@@ -247,11 +248,12 @@ function showRedirectButton() {
   document.getElementById('flow-redirect').style.display = 'block';
 }
 
-function showSigninWidget() {
+function showSigninWidget(stateToken) {
     // Create an instance of the signin widget
     var signIn = new OktaSignIn({
       baseUrl: config.issuer.split('/oauth2')[0],
       clientId: config.clientId,
+      stateToken: stateToken,
       redirectUri: config.redirectUri,
       useInteractionCodeFlow: config.useInteractionCodeFlow,
       authParams: {
@@ -265,7 +267,7 @@ function showSigninWidget() {
         return { type, id };
       }).filter(idpToken => idpToken)
     });
-  
+
     signIn.showSignInToGetTokens({
       el: '#signin-widget',
       state: JSON.stringify(config.state)
@@ -278,12 +280,16 @@ function showSigninWidget() {
     .catch(function(error) {
       console.log('login error', error);
     });
-  
+
     document.getElementById('flow-widget').style.display = 'block'; // show login UI
 }
 
 function showSigninForm() {
   document.getElementById('login-form').style.display = 'block';
+}
+
+function hideSigninForm() {
+  document.getElementById('login-form').style.display = 'none';
 }
 
 function submitSigninForm() {
@@ -296,8 +302,13 @@ function submitSigninForm() {
   .then(function(transaction) {
     if (transaction.status === 'SUCCESS') {
       return authClient.session.setCookieAndRedirect(transaction.sessionToken, config.appUri + '&getTokens=true');
+    } else if (transaction.status == 'MFA_REQUIRED' && config.flow == 'hybrid') {
+      // In hybrid flow when MFA is required, will show signin widget skipping username/password first step
+      hideSigninForm();
+      showSigninWidget(transaction.data.stateToken);
+    } else {
+      throw new Error('We cannot handle the ' + transaction.status + ' status');
     }
-    throw new Error('We cannot handle the ' + transaction.status + ' status');
   })
   .catch(function(err) {
     showError(err);
@@ -429,7 +440,7 @@ function loadConfig() {
   // Read all config from the URL
   var url = new URL(window.location.href);
   var redirectUri = window.location.origin + '/login/callback'; // Should also be set in Okta Admin UI
-  
+
   // Params which are not in the state
   var stateParam = url.searchParams.get('state'); // received on login redirect callback
   var error = url.searchParams.get('error'); // received on login redirect callback
@@ -470,7 +481,7 @@ function loadConfig() {
     clientId = url.searchParams.get('clientId') || config.clientId;
     storage = url.searchParams.get('storage') || config.storage;
     flow = url.searchParams.get('flow') || config.flow;
-    requireUserSession = url.searchParams.get('requireUserSession') ? 
+    requireUserSession = url.searchParams.get('requireUserSession') ?
       url.searchParams.get('requireUserSession')  === 'true' : config.requireUserSession;
     scopes = url.searchParams.get('scopes') ? url.searchParams.get('scopes').split(' ') : config.scopes;
     useInteractionCodeFlow = url.searchParams.get('useInteractionCodeFlow') === 'true' || config.useInteractionCodeFlow;

--- a/samples/generated/static-spa/public/index.html
+++ b/samples/generated/static-spa/public/index.html
@@ -47,21 +47,22 @@
         <label for="issuer">Issuer</label><input id="issuer" name="issuer" type="text" /><br/>
         <label for="clientId">Client ID (SPA App)
         </label><input id="clientId" name="clientId" type="text" /><br/>
-      
+
         <label for="flow">Authentication Flow</label>
         <select id="flow" name="flow" onchange="_onChangeFlow(event)">
           <option value="redirect">Redirect to Okta</option>
           <option value="widget">Okta Signin Widget (self-hosted)</option>
           <option value="form">Custom form (username/passsword)</option>
+          <option value="hybrid">Hybrid form (username/passsword) + MFA Signin Widget</option>
           <!-- Other login flows can be added -->
         </select><br/>
-      
+
         <label for="scopes">Scopes</label><input id="scopes" name="scopes" type="text" /><br/>
-        
+
         <label for="requireUserSession">Require Okta SSO session</label><br/>
         <input id="requireUserSession-on" name="requireUserSession" type="radio" value="true"/>ON<br/>
         <input id="requireUserSession-off" name="requireUserSession" type="radio" value="false"/>OFF<br/>
-      
+
         <label for="storage">Token storage</label>
         <select id="storage" name="storage">
           <option value="localStorage">localStorage</option>
@@ -69,14 +70,14 @@
           <option value="cookie">cookie</option>
           <option value="memory">memory</option>
         </select><br/>
-      
+
         <label for="useInteractionCodeFlow">Use <strong>interaction_code</strong> grant (in signin widget flow)</label><br/>
         <input id="useInteractionCodeFlow-on" name="useInteractionCodeFlow" type="radio" value="true"/>YES<br/>
         <input id="useInteractionCodeFlow-off" name="useInteractionCodeFlow" type="radio" value="false"/>NO<br/>
-        
+
         <label style="display: none" for="idps">IDPs (in format "type:id" space-separated, example: "Facebook:111aaa Google:222bbb")</label>
         <input style="display: none" id="idps" name="idps" type="text" /><br/>
-      
+
         <hr/>
         <input id="login-submit" type="submit" value="Update Config"/>
       </form>


### PR DESCRIPTION
### Description
This PR show how to implement an hybrid authentication using custom login form + Okta Signin Widget

Hybrid flow can be used when you need to show Okta Signin Widget only if there is a multifactor challenge.

To achieve this we use `stateToken` field when initializing the widget. 
As there is no mention in [documentation](https://github.com/okta/okta-signin-widget). We need to be sure this will not be deprecated soon.

```javascript
var signIn = new OktaSignIn({
      ...
      stateToken: 'state token from a previous transaction ie. after MFA_REQUIRED status was returned', 
      ...
});
```